### PR TITLE
Open non-Kagi domains in new window

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1913,6 +1913,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
+ "url",
  "winreg",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,6 +17,7 @@ tauri = { version = "2", features = [ "rustls-tls"] }
 tauri-plugin-opener = "2"
 tauri-plugin-window-state = "2"
 serde_json = "1"
+url = "2"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,22 +10,7 @@
     "frontendDist": "../dist"
   },
   "app": {
-    "windows": [
-      {
-        "title": "Kagi Assistant",
-        "width": 1200,
-        "height": 800,
-        "minWidth": 800,
-        "minHeight": 600,
-        "resizable": true,
-        "fullscreen": false,
-        "center": true,
-        "decorations": true,
-        "visible": true,
-        "label": "main",
-        "url": "https://kagi.com/assistant"
-      }
-    ],
+    "windows": [],
     "security": {
       "csp": null
     },


### PR DESCRIPTION
This behavior fits more with other apps: using the default browser/url handlers for links shown in the Assistant conversations.

Needed to change window initialization to be able to attach url handlers.